### PR TITLE
Back-compatability workaround for CPAN.pm bootstrap

### DIFF
--- a/lib/local/lib.pm
+++ b/lib/local/lib.pm
@@ -418,6 +418,8 @@ sub print_environment_vars_for {
 }
 
 sub environment_vars_string_for {
+  local $ENV{PERL_LOCAL_LIB_ROOT}
+    if caller eq 'CPAN::FirstTime' && CPAN::FirstTime->VERSION < 5.5305;
   my $self = $_[0]->new->activate($_[1]);
   $self->environment_vars_string;
 }


### PR DESCRIPTION
Older CPAN::FirstTime, e.g. as ship with 5.18, don't work with
the current local::lib because of the internal changes around
activation.

This patch zaps PERL_LOCAL_LIB_ROOT in environment_vars_string_for() only
if the caller is an older CPAN::FirstTime.  This restores the ability of
CPAN::FirstTime to bootstrap local::lib and shouldn't affect any other
uses of local::lib.

I have tested this manually on both darwin and linux on a stock
5.18.

